### PR TITLE
added MAC install instructions and other doc changes. Removed data fr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ python/tests/unit_tests/test_defines.v
 ## exclude data 
 data/*
 covg/data/*
+
+python/test_defines.v
+test_defines.v

--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -1,8 +1,12 @@
 core
 =================
 
-:py:mod:`core` contains the basic functionality of :py:mod:`pyripherals`. :py:class:`~pyripherals.core.Register`
-for internal registers, :py:class:`~pyripherals.core.Endpoint` for Opal Kelly Endpoints on the FPGA, and
+:py:mod:`core` contains the basic functionality of :py:mod:`pyripherals`. 
+
+:py:class:`~pyripherals.core.Register` for internal registers, 
+
+:py:class:`~pyripherals.core.Endpoint` for Opal Kelly Endpoints on the FPGA, and
+
 :py:class:`~pyripherals.core.FPGA` for basic FPGA connection and commands.
 
 .. automodule:: pyripherals.core

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -4,13 +4,13 @@ Example
 One example of using :py:mod:`pyripherals` is an impedance analyzer which calculates the impedance of an unknown
 component. For this example you will need an Opal Kelly XEM7310 FPGA connected to your computer as well as a
 `DAC80508 <https://www.ti.com/product/DAC80508>`_ and `ADS8686 <https://www.ti.com/product/ADS8686S>`_
-connected to the FPGA. The pin connections between the FPGA and these peripherals are as follows:
+connected to the FPGA (the ADS8686 is available on an `eval kit <https://www.digikey.com/en/products/detail/texas-instruments/ADS8686SEVM-PDK/11308735?s=N4IgTCBcDaIIYBMDOAOAbOgBCAugXyA>`_ and the DAC8058 could be mounted onto a `VQFN4x4 breakout board <https://www.digikey.com/en/products/detail/chip-quik-inc/IPC0006/5014791>`_). The pin connections between the FPGA on the XEM7310 and these peripherals are as follows:
 
 DAC80508
 
-* SDI - L3
+* SDI - L3 
 
-* SDO - K3
+* SDO - K3 
 
 ADS8686
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -30,7 +30,7 @@ pip
 
 FPGA
 ------------
-To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly.
+To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly. If you are using a MAC see the :ref: `mac_ok_setup`. 
 You will also need to update the config.yaml file. See the :ref:`installation_yaml` section and example.
 
 .. _installation_peripherals:
@@ -65,3 +65,20 @@ after running :py:meth:`pyripherals.utils.create_yaml`. An example YAML is shown
     fpga_bitfile_path: C:/Users/username/my_project/top_level_module.bit
     frontpanel_path: C:/Program Files/Opal Kelly/FrontPanelUSB
     registers_path: C:/Users/username/my_project/Registers.xlsx
+
+.. _mac_ok_setup:
+
+Opal Kelly Setup on MAC
+-----------------------
+The _ok.so shared library needs to be able to "find" the libokFrontPanel.dylib. Navigate to the FrontPanel API directory: e.g. frontpanel/API/Python3/ and check where _ok.so is searching for libokFrontPanel.dylib using ttool
+
+.. code-block:: console 
+
+    $ otool -L _ok.so
+
+This output indicates that the Python import of ok will fail since libok is one directory up. Change this using install_name_tool.
+
+.. code-block:: console 
+
+    $ install_name_tool -change libokFrontPanel.dylib /fullpath/to/libokFrontPanel/libokFrontPanel.dylib _ok.so
+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -70,7 +70,7 @@ after running :py:meth:`pyripherals.utils.create_yaml`. An example YAML is shown
 
 Opal Kelly Setup on MAC
 -----------------------
-The _ok.so shared library needs to be able to "find" the libokFrontPanel.dylib. Navigate to the FrontPanel API directory: e.g. frontpanel/API/Python3/ and check where _ok.so is searching for libokFrontPanel.dylib using ttool
+The _ok.so shared library needs to be able to "find" the libokFrontPanel.dylib. Navigate to the FrontPanel API directory: e.g. frontpanel/API/Python3/ and check where _ok.so is searching for libokFrontPanel.dylib using otool.
 
 .. code-block:: console 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -56,7 +56,9 @@ import :py:meth:`pyripherals.utils.create_yaml` and run it like below.
     YAML created at C:/Users/username/.pyripherals
 
 From there, you can configure the options available by editing the config.yaml file created at the path given
-after running :py:meth:`pyripherals.utils.create_yaml`. An example YAML is shown below.
+after running :py:meth:`pyripherals.utils.create_yaml`. An example YAML is shown below. Note that the paths to
+ep_defines.v, the FPGA bitfile, and the Registers.xlsx spreadsheet go directly to files, but the FrontPanel path
+goes to the FrontPanelUSB folder of your installation.
 
 .. code-block:: yaml
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -30,7 +30,7 @@ pip
 
 FPGA
 ------------
-To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly. If you are using a MAC see the :ref:`mac_ok_setup`. 
+To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly. If you are using a MAC see the :ref:`mac_ok_setup` section.
 You will also need to update the config.yaml file. See the :ref:`installation_yaml` section and example.
 
 .. _installation_peripherals:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -30,7 +30,7 @@ pip
 
 FPGA
 ------------
-To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly. If you are using a MAC see the :ref: `mac_ok_setup`. 
+To use the FPGA class with an Opal Kelly FrontPanel-supported device, you will also need to download the `FrontPanel SDK <https://pins.opalkelly.com/downloads>`_ from Opal Kelly. If you are using a MAC see the :ref:`mac_ok_setup`. 
 You will also need to update the config.yaml file. See the :ref:`installation_yaml` section and example.
 
 .. _installation_peripherals:

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -8,7 +8,7 @@ Tests
     >>> pip install pytest
 
 All tests are available in the `tests folder on the GitHub <https://github.com/Ajstros/pyripherals/tree/main/python/tests>`_
-All automated and working tests can be run with the "usable" marker.
+All automated and working tests can be run with the "usable" marker. To run the tests clone the repository and navigate into the repository. 
 
 .. code-block:: python
 
@@ -20,4 +20,4 @@ More specific marks are available for different setups. Simply replace "usable" 
 
 * fpga_only: use if you have an FPGA connected
 
-* usable: all working automated tests; may require FPGA and connected peripherals 
+* usable: all working automated tests; requires an FPGA and connected peripherals which is very specific to our lab

--- a/python/src/pyripherals/core.py
+++ b/python/src/pyripherals/core.py
@@ -2,10 +2,9 @@
 
 Use Registers for peripherals' internal registers and Endpoints for Opal Kelly Endpoints on the FPGA. 
 
-June 2022
+Abe Stroschein, ajstroschein@stthomas.edu
 
 Lucas Koerner, koer2434@stthomas.edu
-Abe Stroschein, ajstroschein@stthomas.edu
 """
 
 import pandas as pd

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -1,9 +1,8 @@
 """Module containing general functions useful to interfaces.
 
-June 2022
+Abe Stroschein, ajstroschein@stthomas.edu
 
 Lucas Koerner, koer2434@stthomas.edu
-Abe Stroschein, ajstroschein@stthomas.edu
 """
 
 import numpy as np


### PR DESCRIPTION
…om docstrings. Added test_defines.v to .gitignore

Added MAC OK setup instructions to the end of the Installation page. Noted that the _tests_ requires a clone (not just the package). 

Added a link to the ADS8686 eval kit and to the DAC80508 breakout board. 

Slight modifications to Python docstrings to improve the formatting on readthedocs.

When running tests _test_defines.v_ was created so added that to the .gitignore