### PR TITLE
Move DDR setup functions to DDR3 class 

### DIFF
--- a/examples/impedance_analyzer.py
+++ b/examples/impedance_analyzer.py
@@ -192,6 +192,7 @@ if not os.path.exists(data_dir):
     os.makedirs(data_dir)
 file_name = 'impedance_analyzer'
 
+time.sleep(23)
 # saves data to a file; returns to the workspace the deswizzled DDR data of the last repeat
 chan_data_one_repeat = ddr.save_data(data_dir, file_name.format(0) + '.h5', num_repeats=8,
                                     blk_multiples=40)  # blk multiples multiple of 10

--- a/examples/impedance_analyzer.py
+++ b/examples/impedance_analyzer.py
@@ -89,21 +89,6 @@ ADS8686_A_CHAN = 7                      # ADS8686 input from side A reading DAC8
 ADS8686_B_CHAN = 3                      # ADS8686 input from side B reading unknown impedance voltage
 
 
-# Helper functions for DDR3
-def ddr_write_setup():
-    ddr.set_adcs_connected()
-    ddr.clear_dac_read()
-    ddr.clear_adc_write()
-    ddr.reset_fifo(name='ALL')
-    ddr.reset_mig_interface()
-    ad7961s[0].reset_trig()
-
-
-def ddr_write_finish():
-    # reenable both DACs
-    ddr.set_adc_dac_simultaneous()  # enable DAC playback and ADC writing to DDR
-
-
 # --- Set up FPGA, DDR3, DAC80508, ADS8686 ---
 f = FPGA()
 f.init_device()
@@ -179,11 +164,11 @@ ddr.data_arrays[1] = np.bitwise_or(ddr.data_arrays[1], (DAC80508_OUT_CHAN & 0b00
 # Set voltage
 ddr.data_arrays[6] = v_in_code.astype(np.uint16)
 
-ddr_write_setup()
+ddr.write_setup()
 # ddr.write_channels()   # Double write to ensure good output
 g_buf = ddr.write_channels()
 ddr.reset_mig_interface()
-ddr_write_finish()
+ddr.write_finish()
 
 ddr.clear_adc_read()
 ddr.clear_adc_write()
@@ -192,7 +177,7 @@ ddr.reset_fifo(name='ADC_IN')
 ddr.reset_fifo(name='ADC_TRANSFER')
 ddr.reset_mig_interface()
 
-ddr_write_finish()
+ddr.write_finish()
 time.sleep(0.01)
 
 # # --- Read input and ouput voltage signals ---

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -789,10 +789,13 @@ class DDR3():
         print('Set index is no longer used. Index is fixed to: {}'.format(
             self.parameters['port1_index']))
 
-    def write_setup(self):
+    def write_setup(self, data_driven_clock=True):
         """Set up DDR for writing."""
 
-        self.set_adcs_connected()
+        if data_driven_clock:
+            self.set_adcs_connected()
+        else:
+            self.clear_adcs_connected()
         self.clear_dac_read()
         self.clear_adc_write()
         self.clear_adc_read()    # Stop putting data in outgoing FIFO for Pipe read

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -281,9 +281,9 @@ class DDR3():
                 data[(7-i + 1)::8] = self.data_arrays[i]
 
         print('Length of data DDR data [2 byte words] = {}'.format(len(data)))
-        return self.write(bytearray(data), set_ddr_read=set_ddr_read)
+        return self.write_buf(bytearray(data), set_ddr_read=set_ddr_read)
 
-    def write(self, buf, set_ddr_read=True):
+    def write_buf(self, buf, set_ddr_read=True):
         """Write a bytearray to the DDR3.
 
         Parameters
@@ -788,3 +788,32 @@ class DDR3():
         """
         print('Set index is no longer used. Index is fixed to: {}'.format(
             self.parameters['port1_index']))
+
+    def write_setup(self):
+        """Set up DDR for writing."""
+
+        self.ddr.set_adcs_connected()
+        self.ddr.clear_dac_read()
+        self.ddr.clear_adc_write()
+        self.ddr.clear_adc_read()    # Stop putting data in outgoing FIFO for Pipe read
+        self.ddr.reset_fifo(name='ALL')
+        self.ddr.reset_mig_interface()
+
+    def repeat_setup(self):
+        """Setup for reading new data without writing to the DDR again."""
+
+        # stop access to the FIFOs so that after reset of the FIFO(s) no new data is added/extracted
+        self.ddr.clear_adc_read()
+        self.ddr.clear_adc_write()
+        self.ddr.clear_dac_read()
+        self.ddr.reset_fifo(name='ALL')
+        # self.fpga.send_trig(self.endpoints['UI_RESET'])
+        self.ddr.reset_mig_interface()
+        # note that the MIG interface addresses are driven by the FIFOs so will idle
+        # until the FIFOs are reenable with write_finish()
+        self.write_finish()
+        time.sleep(0.01)
+
+    def write_finish(self):
+        # reenable both DACs
+        self.ddr.set_adc_dac_simultaneous()  # enable DAC playback and ADC writing to DDR

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -792,23 +792,23 @@ class DDR3():
     def write_setup(self):
         """Set up DDR for writing."""
 
-        self.ddr.set_adcs_connected()
-        self.ddr.clear_dac_read()
-        self.ddr.clear_adc_write()
-        self.ddr.clear_adc_read()    # Stop putting data in outgoing FIFO for Pipe read
-        self.ddr.reset_fifo(name='ALL')
-        self.ddr.reset_mig_interface()
+        self.set_adcs_connected()
+        self.clear_dac_read()
+        self.clear_adc_write()
+        self.clear_adc_read()    # Stop putting data in outgoing FIFO for Pipe read
+        self.reset_fifo(name='ALL')
+        self.reset_mig_interface()
 
     def repeat_setup(self):
         """Setup for reading new data without writing to the DDR again."""
 
         # stop access to the FIFOs so that after reset of the FIFO(s) no new data is added/extracted
-        self.ddr.clear_adc_read()
-        self.ddr.clear_adc_write()
-        self.ddr.clear_dac_read()
-        self.ddr.reset_fifo(name='ALL')
+        self.clear_adc_read()
+        self.clear_adc_write()
+        self.clear_dac_read()
+        self.reset_fifo(name='ALL')
         # self.fpga.send_trig(self.endpoints['UI_RESET'])
-        self.ddr.reset_mig_interface()
+        self.reset_mig_interface()
         # note that the MIG interface addresses are driven by the FIFOs so will idle
         # until the FIFOs are reenable with write_finish()
         self.write_finish()
@@ -816,4 +816,4 @@ class DDR3():
 
     def write_finish(self):
         # reenable both DACs
-        self.ddr.set_adc_dac_simultaneous()  # enable DAC playback and ADC writing to DDR
+        self.set_adc_dac_simultaneous()  # enable DAC playback and ADC writing to DDR


### PR DESCRIPTION
Some functions are used in examples/impedance_analyzer.py that are useful more generally. They deal with the DDR, so they go in the DDR3 class. They are:

- ddr_write_setup -> now DDR3.write_setup
- ddr_write_finish -> now DDR3.write_finish
- ddr_repeat_setup -> (new) DDR3.repeat_setup for reading from DDR again without rewriting data