### PR TITLE
Faster twos_comp

### DIFF
--- a/python/src/pyripherals/peripherals/ADCDATA.py
+++ b/python/src/pyripherals/peripherals/ADCDATA.py
@@ -1,5 +1,5 @@
 from ..core import Endpoint
-from ..utils import twos_comp
+from ..utils import custom_signed_to_int
 import numpy as np
 import time
 
@@ -37,7 +37,7 @@ class ADCDATA():
     def convert_twos(self, d):
         """Convert data to integer two's complement representation."""
 
-        return twos_comp(d, self.num_bits)
+        return custom_signed_to_int(d, self.num_bits)
 
     def convert_data(self, buf):
         """Deswizle and convert the twos complement representation."""
@@ -46,17 +46,17 @@ class ADCDATA():
 
     # TODO: test composite ADC function that enables, reads, converts and plots
     # TODO: incorporate/connect QT graphing (UIscript.py)
-    def read(self, twos_comp_conv=True):
+    def read(self, custom_signed_to_int_conv=True):
         # TODO: add method docstring
 
         s, e = self.fpga.read_pipe_out(self.endpoints['PIPE_OUT'].address)
-        if twos_comp_conv:
+        if custom_signed_to_int_conv:
             data = self.convert_data(s)
         else:
             data = self.deswizzle(s)
         return data
 
-    def stream_mult(self, swps=4, twos_comp_conv=True, data_len=1024):
+    def stream_mult(self, swps=4, custom_signed_to_int_conv=True, data_len=1024):
         # TODO: add method docstring
         print('ADC stream multiple')
         cnt = 0
@@ -82,7 +82,7 @@ class ADCDATA():
         if not timeout_flg:
             print('ADC stream_mult timed out')
             return -1
-        if twos_comp_conv:
+        if custom_signed_to_int_conv:
             data = self.convert_data(st)
         else:
             data = self.deswizzle(st)

--- a/python/src/pyripherals/peripherals/ADS8686.py
+++ b/python/src/pyripherals/peripherals/ADS8686.py
@@ -1,5 +1,5 @@
 from ..core import Endpoint, Register
-from ..utils import twos_comp
+from ..utils import custom_signed_to_int
 from .SPIController import SPIController
 from .ADCDATA import ADCDATA
 
@@ -95,7 +95,7 @@ class ADS8686(SPIController, ADCDATA):
         Uses the stored gain range. reg_val can be list of ints or int
         """
         #  TODO: setup for sequence of channels
-        val = twos_comp(reg_val, 16)  # 16-bit channel readings
+        val = custom_signed_to_int(reg_val, 16)  # 16-bit channel readings
         lsb = (self.ranges[chan_num]*2)/2**16
         return val*lsb
 

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -1,5 +1,5 @@
 from ..core import Endpoint
-from ..utils import test_bit, gen_mask, twos_comp, binary_twos_comp
+from ..utils import test_bit, gen_mask, twos_comp, twos_comp
 import numpy as np
 import time
 import os
@@ -680,8 +680,8 @@ class DDR3():
             # dac channels 4,5 are available but not every sample. skip for now. TODO: add channels 4,5
 
             ads = {}
-            ads['A'] = binary_twos_comp(chan_data[7][0::5], 16)
-            ads['B'] = binary_twos_comp(chan_data[7][1::5], 16)
+            ads['A'] = twos_comp(chan_data[7][0::5], 16)
+            ads['B'] = twos_comp(chan_data[7][1::5], 16)
 
             error = False
             # check that the constant values are constant

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -1,5 +1,5 @@
 from ..core import Endpoint
-from ..utils import test_bit, gen_mask, twos_comp, twos_comp
+from ..utils import test_bit, gen_mask, custom_signed_to_int
 import numpy as np
 import time
 import os
@@ -581,7 +581,7 @@ class DDR3():
             chan_data[3] = chan_data_swz[1]
             if convert_twos:
                 for i in range(4):
-                    chan_data[i] = twos_comp(chan_data[i], bits)
+                    chan_data[i] = custom_signed_to_int(chan_data[i], bits)
 
         # first version of ADC data before DACs + timestamps are stored
         if self.parameters['data_version'] == 'TIMESTAMPS':
@@ -652,7 +652,7 @@ class DDR3():
 
             adc_data = {}
             for i in range(4):
-                # adc_data[i] = twos_comp(chan_data[i], 16)
+                # adc_data[i] = custom_signed_to_int(chan_data[i], 16)
                 adc_data[i] = chan_data[i]
 
             lsb = chan_data[6][0::5].astype(np.uint64)
@@ -680,8 +680,8 @@ class DDR3():
             # dac channels 4,5 are available but not every sample. skip for now. TODO: add channels 4,5
 
             ads = {}
-            ads['A'] = twos_comp(chan_data[7][0::5], 16)
-            ads['B'] = twos_comp(chan_data[7][1::5], 16)
+            ads['A'] = custom_signed_to_int(chan_data[7][0::5], 16)
+            ads['B'] = custom_signed_to_int(chan_data[7][1::5], 16)
 
             error = False
             # check that the constant values are constant

--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -1,5 +1,5 @@
 from ..core import Endpoint
-from ..utils import test_bit, gen_mask, twos_comp
+from ..utils import test_bit, gen_mask, twos_comp, binary_twos_comp
 import numpy as np
 import time
 import os
@@ -680,8 +680,8 @@ class DDR3():
             # dac channels 4,5 are available but not every sample. skip for now. TODO: add channels 4,5
 
             ads = {}
-            ads['A'] = twos_comp(chan_data[7][0::5], 16)
-            ads['B'] = twos_comp(chan_data[7][1::5], 16)
+            ads['A'] = binary_twos_comp(chan_data[7][0::5], 16)
+            ads['B'] = binary_twos_comp(chan_data[7][1::5], 16)
 
             error = False
             # check that the constant values are constant

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -237,8 +237,8 @@ def to_voltage(data, num_bits, voltage_range, use_twos_comp=False):
 
     bit_voltage = voltage_range / (2 ** num_bits)
     if use_twos_comp:
-        twos_data = custom_signed_to_int(data=data, num_bits=num_bits)
-        data = np.where(np.array(data) >= (1 << num_bits - 1), -1 * twos_data, twos_data)
+        data = custom_signed_to_int(data=data, num_bits=num_bits)
+        # data = np.where(np.array(data) >= (1 << num_bits - 1), -1 * twos_data, twos_data)
 
     if type(data) is np.ndarray:
         voltage = data * bit_voltage

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -248,7 +248,7 @@ def to_voltage(data, num_bits, voltage_range, use_twos_comp=False):
 
     bit_voltage = voltage_range / (2 ** num_bits)
     if use_twos_comp:
-        twos_data = twos_comp(data=data, num_bits=num_bits)
+        twos_data = custom_signed_to_int(data=data, num_bits=num_bits)
         data = np.where(np.array(data) >= (1 << num_bits - 1), -1 * twos_data, twos_data)
 
     if type(data) is np.ndarray:
@@ -302,7 +302,7 @@ def from_voltage(voltage, num_bits, voltage_range, with_negatives=False):
         raise TypeError(f'from_voltage voltage expected np.integer, np.floating, list, or np.ndarray type, got {type(voltage)}')
 
     if with_negatives:
-        data = twos_comp(data=data, num_bits=num_bits)
+        data = int_to_custom_signed(data=data, num_bits=num_bits)
 
     # Since this system may overflow to 0 on the maximum value, we limit any
     # input voltages of maximum to full-scale.

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -164,19 +164,8 @@ def int_to_custom_signed(data, num_bits):
     array([65531, 5])
     """
 
-    if type(data) is np.ndarray:
-        # Use bitwise_or to invert bits, then add one, then use bitwise_and to keep only num_bits, allowing the rest to overflow out.
-        twos_data = np.where(data & (1 << num_bits - 1), np.bitwise_and(np.bitwise_xor(np.abs(data), 2**num_bits - 1) + 1, 2 ** num_bits - 1), data).astype(int)
-    elif type(data) is list:
-        data = np.array(data)
-        # Use bitwise_or to invert bits, then add one, then use bitwise_and to keep only num_bits, allowing the rest to overflow out.
-        twos_data = np.where(data & (1 << num_bits - 1), np.bitwise_and(np.bitwise_xor(np.abs(data), 2**num_bits - 1) + 1, 2 ** num_bits - 1), data).astype(int)
-    elif np.issubdtype(type(data), np.integer):
-        # Use bitwise_or to invert bits, then add one, then use bitwise_and to keep only num_bits, allowing the rest to overflow out.
-        twos_data = np.bitwise_and(np.bitwise_xor(np.abs(data), 2**num_bits - 1) + 1, 2 ** num_bits - 1) if data & (1 << num_bits - 1) else data
-        twos_data = int(twos_data)
-
-    return twos_data
+    # If int is positive, this should cut off nothing but leading zeros. If negative, it should only cut off leading ones.
+    return np.bitwise_and(data, (1 << num_bits) - 1)
 
 
 def custom_signed_to_int(data, num_bits):

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -64,26 +64,6 @@ def gen_mask(bit_pos):
     mask = sum([(1 << b) for b in bit_pos])
     return mask
 
-def twos_comp(val, bits):
-    """compute the 2's complement of int value val
-        handle an array (list or numpy)
-
-    Use for converting twos complement binary data to a signed integer.
-    """
-
-    def twos_comp_scalar(val, bits):
-        if (val & (1 << (bits - 1))) != 0: # if sign bit is set e.g., 8bit: 128-255
-            val = val - (1 << bits)        # compute negative value
-        return val                         # return positive value as is
-
-    if hasattr(val, "__len__"):
-        tmp_arr = np.array([])
-        for v in val:
-            tmp_arr = np.append(tmp_arr, twos_comp_scalar(v,bits))
-        return tmp_arr
-    else:
-        return twos_comp_scalar(val, bits)
-
 
 def reverse_bits(number, bit_width=8):
     """Return an integer with the reversed bits of the input number."""
@@ -156,7 +136,7 @@ def int_to_list(integer, byteorder='little', num_bytes=None):
         return list_int
 
 
-def binary_twos_comp(data, num_bits):
+def twos_comp(data, num_bits):
     """Apply two's complement using the binary method.
     
     Invert all bits (in num_bits), add 1 (only keeping num_bits).

--- a/python/src/pyripherals/utils.py
+++ b/python/src/pyripherals/utils.py
@@ -193,7 +193,7 @@ def to_voltage(data, num_bits, voltage_range, use_twos_comp=False):
 
     bit_voltage = voltage_range / (2 ** num_bits)
     if use_twos_comp:
-        twos_data = binary_twos_comp(data=data, num_bits=num_bits)
+        twos_data = twos_comp(data=data, num_bits=num_bits)
         data = np.where(np.array(data) >= (1 << num_bits - 1), -1 * twos_data, twos_data)
 
     if type(data) is np.ndarray:
@@ -247,7 +247,7 @@ def from_voltage(voltage, num_bits, voltage_range, with_negatives=False):
         raise TypeError(f'from_voltage voltage expected np.integer, np.floating, list, or np.ndarray type, got {type(voltage)}')
 
     if with_negatives:
-        data = binary_twos_comp(data=data, num_bits=num_bits)
+        data = twos_comp(data=data, num_bits=num_bits)
 
     # Since this system may overflow to 0 on the maximum value, we limit any
     # input voltages of maximum to full-scale.


### PR DESCRIPTION
Recently, we added `binary_twos_comp` in the `pyripherals.utils` module. We already had `twos_comp`, but this was meant to be a bit clearer and perform the complete binary two's complement usable going to or from twos_complement form. It also takes advantage of numpy arrays rather than the for loops found in `twos_comp`. This makes `binary_twos_comp` **clearer**, **faster**, and **more generally applicable** than `twos_comp`. For that reason, we are replacing `twos_comp` with `binary_twos_comp`, now renamed to `twos_comp`.