### PR TITLE
Fix bug where end of last save gets cut off and not all data is returned

### DIFF
--- a/python/src/pyripherals/peripherals/DDR3.py
+++ b/python/src/pyripherals/peripherals/DDR3.py
@@ -771,6 +771,8 @@ class DDR3():
                 new_data_index = data_set.shape[1]
                 if data_set.attrs['bitfile_version'] != self.fpga.bitfile_version:
                     raise Exception(f"File {os.path.join(data_dir, file_name)} bitfile version {data_set.attrs['bitfile_version']} does not match FPGA bitfile version {self.fpga.bitfile_version}")
+                # Make space for first round of new data. Not needed when not appending because the data set is created with chunk_size space
+                data_set.resize(data_set.shape[1] + chunk_size, axis=1)
             else:
                 data_set = file.create_dataset("adc", (self.parameters['adc_channels'], chunk_size), maxshape=(
                     self.parameters['adc_channels'], None))


### PR DESCRIPTION
When I added the `append` parameter to `DDR3.save_data`, I accidentally created a bug that caused newly saved data to be shifted such that it overlapped with previous data. This fixes the issue by resizing the existing h5 dataset to accommodate the incoming first chunk when `append=True`.