### PR TITLE
Add ADS8686.sequencer_setup attribute

### DIFF
--- a/python/src/pyripherals/peripherals/ADS8686.py
+++ b/python/src/pyripherals/peripherals/ADS8686.py
@@ -24,6 +24,7 @@ class ADS8686(SPIController, ADCDATA):
         self.ranges = [5]*16  # voltage ranges of all 16 channels
         self.num_bits = 16
         self.name = 'ADS8686'
+        self.sequencer_setup = None
 
     def write(self, msg, reg_name):
         """Write to an internal register on the chip."""
@@ -207,6 +208,10 @@ class ADS8686(SPIController, ADCDATA):
                    'seq' + str(len(codes) - 1))
         # enable the sequencer
         self.write(base_creg | 0x20, 'config')
+
+        # Store sequencer setup in attribute so it can be accessed later for data processing
+        self.sequencer_setup = chan_list
+
         return codes
 
     def hw_reset(self, val=True):


### PR DESCRIPTION
Add `ADS8686.sequencer_setup` attribute to keep track of the sequencer setup used. This is important for decoding the data later.
- `__init__` method starts `sequencer_setup = None`
- `setup_sequencer` assigns the given `chan_list` argument to `sequencer_setup` at the end of the method